### PR TITLE
try to Re-Use existing vcenter connection

### DIFF
--- a/Import-VIRole.ps1
+++ b/Import-VIRole.ps1
@@ -92,7 +92,7 @@ function Import-VIRole
         {
             if (($global:defaultViServer -eq $vCenter) -and (Get-VIRole)) {
               #Already Have a Valid connection
-              $fred = Get-VIRole
+              $null = Get-VIRole
             } 
             else
             {

--- a/Import-VIRole.ps1
+++ b/Import-VIRole.ps1
@@ -43,7 +43,6 @@ function Import-VIRole
     )
 
     Process {
-
         Write-Verbose -Message 'Importing PowerCLI modules and snapins'
         $powercli = Get-PSSnapin -Name VMware.VimAutomation.Core -Registered
         Try 
@@ -88,11 +87,19 @@ function Import-VIRole
         $null = Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -DisplayDeprecationWarnings:$false -Scope User -Confirm:$false
 
         Write-Verbose -Message "Connecting to vCenter server '$vCenter'"
+        
         Try 
         {
-            $null = Connect-VIServer -Server $vCenter -ErrorAction Stop -Session ($global:DefaultVIServers | Where-Object -FilterScript {
+            if (($global:defaultViServer -eq $vCenter) -and (Get-VIRole)) {
+              #Already Have a Valid connection
+              $fred = Get-VIRole
+            } 
+            else
+            {
+                $null = Connect-VIServer -Server $vCenter -ErrorAction Stop -Session ($global:DefaultVIServers | Where-Object -FilterScript {
                     $_.name -eq $vCenter
-            }).sessionId
+                }).sessionId
+            }
         }
         Catch 
         {


### PR DESCRIPTION
Trying to leverage this for the Vester project. Vester assumes there's already a vCenter connection. Modify Import-VIRole to try to use that connection rather than re-running connect-viserver which prompts for creds...
