### PR TITLE
Add Cryptographer permissions

### DIFF
--- a/Roles/vRA-Endpoint-8.json
+++ b/Roles/vRA-Endpoint-8.json
@@ -124,6 +124,10 @@
     "InventoryService.Tagging.DeleteTag",
     "StorageProfile.View",
     "InventoryService.Tagging.EditCategory",
-    "InventoryService.Tagging.CreateCategory"
+    "InventoryService.Tagging.CreateCategory",
+    "Cryptographer.Clone",
+    "Cryptographer.EncryptNew",
+    "Cryptographer.Migrate",
+    "Cryptographer.RegisterVM"
   ]
 }


### PR DESCRIPTION
When working with TPM-enabled VMs (e.g. Windows 11), some Cryptographic permissions are required. See https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-660CCB35-847F-46B3-81CA-10DDDB9D7AA9.html